### PR TITLE
Added mapping of PopOS as debian-family.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1513,6 +1513,7 @@ _OS_FAMILY_MAP = {
     'Funtoo': 'Gentoo',
     'AIX': 'AIX',
     'TurnKey': 'Debian',
+    'Pop': 'Debian',
 }
 
 # Matches any possible format:


### PR DESCRIPTION
### What does this PR do?
Added mapping: Pop -> debian to salt/grains/core.py.

### What issues does this PR fix or reference?
No reference. Pop OS is downstream from debian and Ubuntu.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
